### PR TITLE
feature/sortimages

### DIFF
--- a/app/build/app/templates/workspace.html
+++ b/app/build/app/templates/workspace.html
@@ -27,6 +27,20 @@
                 </div>
                 <input type="button" class="btn btn-primary" value="Upload Files" ng-disabled="wc.Droplet.interface.isUploading() || wc.filesToUpload == 0" ng-click="wc.Droplet.uploadFiles()" />
                 <label>Total files to upload:</label> {{wc.filesToUpload}}
+                
+                <div style="margin-top: 20px">
+                    <div class="btn-group" uib-dropdown>
+                        <button id="sort_images_button" type="button" class="btn btn-default" uib-dropdown-toggle ng-disabled="disabled">
+                          Sort Images <span class="caret"></span>
+                        </button>
+                        <ul uib-dropdown-menu role="menu" aria-labelledby="single-button">
+                            <li role="menuitem" ng-repeat="choice in wc.sortChoices">
+                                <a href="#" ng-click="wc.onClickSortLibrary($event, choice)">{{choice.label}}</a>
+                            </li>
+                        </ul>
+                    </div>
+                </div>
+                
                 <ul class="files">
                   <li ng-if="courseImage.image_url" ng-repeat="courseImage in wc.courseImages track by $index">
                     <droplet-thumb ng-model="courseImage"></droplet-thumb>

--- a/app/src/js/controllers/WorkspaceController.js
+++ b/app/src/js/controllers/WorkspaceController.js
@@ -182,6 +182,15 @@ angular.module('media_manager')
       }
     };
   })();
+  
+  wc.onClickSortLibrary = function($event, choice) {
+    $event.preventDefault();
+    wc.sortLibrary(choice);
+  };
+  
+  wc.sortLibrary = function(choice) {
+    CourseCache.updateSort(choice.name, choice.dir).sortImages();
+  };
 
 
   Breadcrumbs.home().addCrumb("Manage Collection", $location.url());
@@ -198,7 +207,15 @@ angular.module('media_manager')
   wc.canEdit = AppConfig.perms.edit;
   wc.filesToUpload = 0;
   wc.notifications = Notifications;
+  wc.sortChoices = [
+    {'label': 'Newest to Oldest', 'name': 'created', 'dir': 'desc'},
+    {'label': 'Oldest to Newest', 'name': 'created', 'dir': 'asc'},
+    //{'label': 'Last Updated', 'name': 'updated', 'dir': 'desc'},
+    {'label': 'Title', 'name': 'title', 'dir': 'asc'},
+  ];
   
+  wc.sortLibrary(wc.sortChoices[0]);
+
   wc.notifications.clear();
   
   $scope.$on('$dropletReady', Droplet.onReady);
@@ -217,10 +234,10 @@ angular.module('media_manager')
   $scope.$on('$dropletSuccess', Droplet.onSuccess(function(event, response, files) {
       if (angular.isArray(response)) {
         for(var i = 0; i < response.length; i++) {
-          CourseCache.images.push(response[i]);
+          CourseCache.addImage(response[i]);
         }
       } else {
-        CourseCache.images.push(response);
+        CourseCache.addImage(response);
       }
       wc.filesToUpload = Droplet.getTotalValid();
       wc.notifications.clear().success("Images uploaded successfully");

--- a/app/src/js/services/ImageBehavior.js
+++ b/app/src/js/services/ImageBehavior.js
@@ -5,19 +5,7 @@ angular.module('media_manager')
     service.actuallyDeleteImage = function(id) {
         var image = new Image({ id: id });
         return image.$delete(function() {
-            var remove_at_idx = -1;
-            var images = CourseCache.images;
-            for(var idx = 0; idx < images.length; idx++) {
-                if (images[idx].id == id) {
-                    remove_at_idx = idx;
-                    break;
-                }
-            }
-            if (remove_at_idx >= 0) {
-                $log.debug("removing image id ", id, " from cache at index", remove_at_idx);
-                images.splice(remove_at_idx, 1);
-                CourseCache.current_image = CourseCache.getPrevImage(id);
-            }
+            CourseCache.removeImage(id);
         });
     };
 
@@ -28,10 +16,8 @@ angular.module('media_manager')
             templateUrl: '/static/app/templates/confirmDelete.html',
             controller: ['$scope', function($scope) {
                 var cd = this;
-                console.log("id: " + id);
-                console.log(CourseCache.images);
                 var image = CourseCache.getImageById(id);
-                console.log(image);
+                console.log("id:", id, "image:", image, "images:", CourseCache.images);
                 cd.confirm_msg = "Are you sure you want to delete image " + image.title + " (ID:" + image.id + ")? ";
                 cd.ok = function() {
                     var deletePromise = service.actuallyDeleteImage(id);

--- a/app/src/templates/workspace.html
+++ b/app/src/templates/workspace.html
@@ -27,6 +27,20 @@
                 </div>
                 <input type="button" class="btn btn-primary" value="Upload Files" ng-disabled="wc.Droplet.interface.isUploading() || wc.filesToUpload == 0" ng-click="wc.Droplet.uploadFiles()" />
                 <label>Total files to upload:</label> {{wc.filesToUpload}}
+                
+                <div style="margin-top: 20px">
+                    <div class="btn-group" uib-dropdown>
+                        <button id="sort_images_button" type="button" class="btn btn-default" uib-dropdown-toggle ng-disabled="disabled">
+                          Sort Images <span class="caret"></span>
+                        </button>
+                        <ul uib-dropdown-menu role="menu" aria-labelledby="single-button">
+                            <li role="menuitem" ng-repeat="choice in wc.sortChoices">
+                                <a href="#" ng-click="wc.onClickSortLibrary($event, choice)">{{choice.label}}</a>
+                            </li>
+                        </ul>
+                    </div>
+                </div>
+                
                 <ul class="files">
                   <li ng-if="courseImage.image_url" ng-repeat="courseImage in wc.courseImages track by $index">
                     <droplet-thumb ng-model="courseImage"></droplet-thumb>


### PR DESCRIPTION
This PR adds the ability to sort images in the image library by:

- Newest to Oldest (date created desc)
- Oldest to Newest (date created asc)
- Title (title asc)

The sorting is "sticky" because once the sort is selected, it should persist across collections and if/when new images are uploaded, the sort should be applied automatically.

It should be flexible enough so that we can introduce additional sort options as needed. All of the sort logic is contained in the **CourseCache** service.

@jazahn review?