### PR TITLE
feature/travisci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,18 @@
+sudo: false # use new travis infrastructure
+language: python
+python:
+  - "2.7"
+env:
+    - DJANGO_SETTINGS_MODULE="media_management_lti.settings.local"
+install:
+    - pip install -r media_management_lti/requirements/local.txt --use-mirrors
+before_script:
+    - psql -c 'DROP DATABASE IF EXISTS media_management_lti;' -U postgres
+    - psql -c "CREATE USER media_management_lti WITH PASSWORD 'media_management_lti';" -U postgres
+    - psql -c 'ALTER USER media_management_lti CREATEDB;' -U postgres
+    - psql -c 'CREATE DATABASE media_management_lti;' -U postgres
+    - psql -c 'GRANT ALL PRIVILEGES ON DATABASE media_management_lti TO media_management_lti;' -U postgres
+    - cp -v media_management_lti/settings/secure.py.example media_management_lti/settings/secure.py
+script:
+    - python manage.py migrate --noinput
+    - python manage.py test media_manager

--- a/README.md
+++ b/README.md
@@ -16,3 +16,4 @@ Note: the port forwarding for vagrant ssh is assuming you have the [API componen
 
 Optional step: run `python manage.py collectstatic` before runserver to install all nodejs dependencies and build the JS/CSS.
 
+

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/Harvard-ATG/media_management_lti.svg)](https://travis-ci.org/Harvard-ATG/media_management_lti)
+
 ### Quickstart
 
 ```sh
@@ -11,3 +13,6 @@ $ python manage.py runserver 0.0.0.0:8080
 ```
 
 Note: the port forwarding for vagrant ssh is assuming you have the [API component](https://github.com/Harvard-ATG/media_management_api) running on 8000
+
+Optional step: run `python manage.py collectstatic` before runserver to install all nodejs dependencies and build the JS/CSS.
+

--- a/README.md
+++ b/README.md
@@ -16,4 +16,3 @@ Note: the port forwarding for vagrant ssh is assuming you have the [API componen
 
 Optional step: run `python manage.py collectstatic` before runserver to install all nodejs dependencies and build the JS/CSS.
 
-


### PR DESCRIPTION
Setup Travis CI for this project (issue #47).

This is a basic travis config that will automatically setup and run python/django unit tests for the `media_manager` app. See [travis build 1](https://travis-ci.org/Harvard-ATG/media_management_lti/builds/120968529) for example. 

This PR also adds the "build" icon to the README page.

@jazahn review?