### PR TITLE
Feature/collection desc

### DIFF
--- a/app/src/css/collection.css
+++ b/app/src/css/collection.css
@@ -25,3 +25,6 @@
 .collection-edit-button {
   border: none;
 }
+#image-collection-panel .form-inline {
+  margin-top: 5px;
+}

--- a/app/src/js/controllers/WorkspaceController.js
+++ b/app/src/js/controllers/WorkspaceController.js
@@ -174,7 +174,6 @@ angular.module('media_manager')
     return Collection.save({}, wc.collection, function(data){
       wc.collection.id = data.id;
       wc.courseCollections.push(wc.collection);
-      $location.path('/collections/');
     });
   };
 

--- a/app/src/js/controllers/WorkspaceController.js
+++ b/app/src/js/controllers/WorkspaceController.js
@@ -174,6 +174,7 @@ angular.module('media_manager')
     return Collection.save({}, wc.collection, function(data){
       wc.collection.id = data.id;
       wc.courseCollections.push(wc.collection);
+      $location.path('/collections/');
     });
   };
 

--- a/app/src/templates/workspace.html
+++ b/app/src/templates/workspace.html
@@ -29,8 +29,8 @@
           <div class="form-inline" ng-class="{hidden: !collectionDescForm.$visible}">
             <div class="form-group">
               <label for="collectionDescForm">Description</label>
-              <div class="input-group" style="width: 400px;">
-                <div class="form-control" style="overflow:hidden"  editable-textarea="wc.collection.description" e-form="collectionDescForm" e-name="collectionDescForm" e-rows="10" e-cols="60" onaftersave="wc.saveCollection()" ng-click="collectionDescForm.$show()">
+              <div class="input-group">
+                <div class="form-control" style="overflow:hidden"  editable-textarea="wc.collection.description" e-form="collectionDescForm" e-name="collectionDescForm" e-rows="10" e-cols="50" onaftersave="wc.saveCollection()" ng-click="collectionDescForm.$show()">
                   {{wc.collection.description||'No Description'}}
                 </div>
                 <div class="input-group-btn">

--- a/app/src/templates/workspace.html
+++ b/app/src/templates/workspace.html
@@ -14,13 +14,24 @@
         <div class="panel-heading">
           <div class="form-inline">
             <div class="form-group">
-              <label>Collection</label>
+              <label for="collectionTitleForm">Collection</label>
               <div class="input-group" style="width: 400px;">
-                <div class="form-control" editable-text="wc.collection.title" e-form="collectionTitleForm" onaftersave="wc.saveCollection()" ng-click="collectionTitleForm.$show()">
+                <div class="form-control" editable-text="wc.collection.title" e-form="collectionTitleForm" e-name="collectionTitleForm" onaftersave="wc.saveCollection()" ng-click="collectionTitleForm.$show()">
                   {{wc.collection.title||'Untitled'}}
                 </div>
                 <div class="input-group-btn">
                   <button class="btn btn-primary" ng-click="collectionTitleForm.$show()" ng-hide="collectionTitleForm.$visible">Edit</button>
+                </div>
+              </div>
+            </div>
+            <div class="form-group">
+              <label for="collectionDescForm">Description</label>
+              <div class="input-group" style="width: 400px;">
+                <div class="form-control" style="overflow:hidden"  editable-textarea="wc.collection.description" e-form="collectionDescForm" e-name="collectionDescForm" e-rows="7" e-cols="40" onaftersave="wc.saveCollection()" ng-click="collectionDescForm.$show()">
+                  {{wc.collection.description||'No Description'}}
+                </div>
+                <div class="input-group-btn">
+                  <button class="btn btn-primary" ng-click="collectionDescForm.$show()" ng-hide="collectionDescForm.$visible">Edit</button>
                 </div>
               </div>
             </div>

--- a/app/src/templates/workspace.html
+++ b/app/src/templates/workspace.html
@@ -16,7 +16,7 @@
             <div class="form-group">
               <label for="collectionTitleForm">Collection</label>
               <div class="input-group">
-                <div class="form-control" style="min-width: 300px" editable-text="wc.collection.title" e-form="collectionTitleForm" e-name="collectionTitleForm" e-maxlength="255" onaftersave="wc.saveCollection()" ng-click="collectionTitleForm.$show()">
+                <div class="form-control" style="min-width: 200px" editable-text="wc.collection.title" e-form="collectionTitleForm" e-name="collectionTitleForm" e-maxlength="255" onaftersave="wc.saveCollection()" ng-click="collectionTitleForm.$show()">
                   {{wc.collection.title||'Untitled'}}
                 </div>
                 <div class="input-group-btn">

--- a/app/src/templates/workspace.html
+++ b/app/src/templates/workspace.html
@@ -24,9 +24,9 @@
                 </div>
               </div>
             </div>
-			<button class="btn btn-default" ng-click="collectionDescForm.$show()" ng-hide="collectionDescForm.$visible">Edit Description</button>
-		  </div>
-		  <div class="form-inline" ng-class="{hidden: !collectionDescForm.$visible}">
+            <button class="btn btn-default" ng-click="collectionDescForm.$show()" ng-hide="collectionDescForm.$visible">Edit Description</button>
+          </div>
+          <div class="form-inline" ng-class="{hidden: !collectionDescForm.$visible}">
             <div class="form-group">
               <label for="collectionDescForm">Description</label>
               <div class="input-group" style="width: 400px;">

--- a/app/src/templates/workspace.html
+++ b/app/src/templates/workspace.html
@@ -15,8 +15,8 @@
           <div class="form-inline">
             <div class="form-group">
               <label for="collectionTitleForm">Collection</label>
-              <div class="input-group" style="width: 400px;">
-                <div class="form-control" editable-text="wc.collection.title" e-form="collectionTitleForm" e-name="collectionTitleForm" onaftersave="wc.saveCollection()" ng-click="collectionTitleForm.$show()">
+              <div class="input-group">
+                <div class="form-control" style="min-width: 300px" editable-text="wc.collection.title" e-form="collectionTitleForm" e-name="collectionTitleForm" e-maxlength="255" onaftersave="wc.saveCollection()" ng-click="collectionTitleForm.$show()">
                   {{wc.collection.title||'Untitled'}}
                 </div>
                 <div class="input-group-btn">
@@ -24,10 +24,13 @@
                 </div>
               </div>
             </div>
+			<button class="btn btn-default" ng-click="collectionDescForm.$show()" ng-hide="collectionDescForm.$visible">Edit Description</button>
+		  </div>
+		  <div class="form-inline" ng-class="{hidden: !collectionDescForm.$visible}">
             <div class="form-group">
               <label for="collectionDescForm">Description</label>
               <div class="input-group" style="width: 400px;">
-                <div class="form-control" style="overflow:hidden"  editable-textarea="wc.collection.description" e-form="collectionDescForm" e-name="collectionDescForm" e-rows="7" e-cols="40" onaftersave="wc.saveCollection()" ng-click="collectionDescForm.$show()">
+                <div class="form-control" style="overflow:hidden"  editable-textarea="wc.collection.description" e-form="collectionDescForm" e-name="collectionDescForm" e-rows="10" e-cols="60" onaftersave="wc.saveCollection()" ng-click="collectionDescForm.$show()">
                   {{wc.collection.description||'No Description'}}
                 </div>
                 <div class="input-group-btn">

--- a/app/src/tests/controllers/WorkspaceControllerSpec.js
+++ b/app/src/tests/controllers/WorkspaceControllerSpec.js
@@ -1,14 +1,81 @@
 describe("WorkspaceController", function(){
   var workspaceController;
+  var $location;
+  var $log;
 
+  beforeEach(function() {
+    module('media_manager'); 
 
-  describe("layout", function(){
-    describe("add new image button", function(){
-      it("should expand the size of the library", function(){
-        expect(workspaceController).toBeUndefined();
-
+    module(function($provide){
+      var deps = ['Course', 'CollectionBehavior', 'ImageLightBox'];
+      deps.forEach(function(dep) {
+        $provide.service(dep, function(){});
       });
+      $provide.service('AppConfig', function() {
+        this.perms = {edit:true};
+      });
+      $provide.service('Breadcrumbs', function() {
+        this.home = function() { return this; };
+        this.addCrumb = function() { return this; };
+      });
+      $provide.service('CourseCache', function() {
+        this.load = function() {};
+        this.updateSort = function() { return this; };
+        this.sortImages = function() {};
+      });
+      $provide.service('Droplet', function() {
+        this.onReady = function() {};
+        this.onError = function() {};
+        this.onFileAdded = function() {};
+        this.onFileDeleted = function() {};
+        this.onSuccess = function() {};
+      });
+      $provide.service('Notifications', function() {
+        this.clear = function() {};
+      });
+      $provide.service('Preferences', function() {
+        this.get = function() {};
+      });
+      $provide.service('Collection', function() {
+        var Collection = function() {
+        };
+        Collection.save = function(params, postData, success, error) {
+          var data = {};
+          success(data);
+          return {};
+        };
+        return Collection
+      });
+    });
 
+    inject(function($controller, $rootScope, _$log_, _$location_) {
+      var scope = $rootScope.$new();
+      var routeParams = {collectionId:undefined};
+      $location = _$location_;
+      $log = _$log_;
+      workspaceController = $controller('WorkspaceController', {
+        '$scope': scope,
+        '$routeParams': routeParams,
+        '$log': $log,
+        '$location': $location
+      });
+      workspaceController.courseCollections = [];
     });
   });
+
+  describe("test initialization", function(){
+    it("controller should be defined", function(){
+      expect(workspaceController).not.toBeUndefined();
+    });
+  });
+  
+  describe("saving collection", function() {
+    it("should not redirect back to the index", function() {
+      console.log("save collection test");
+      spyOn($location, 'path');
+      workspaceController.saveCollection();
+      expect($location.path).not.toHaveBeenCalled();
+    });
+  });
+
 });

--- a/app/src/tests/controllers/WorkspaceControllerSpec.js
+++ b/app/src/tests/controllers/WorkspaceControllerSpec.js
@@ -71,7 +71,6 @@ describe("WorkspaceController", function(){
   
   describe("saving collection", function() {
     it("should not redirect back to the index", function() {
-      console.log("save collection test");
       spyOn($location, 'path');
       workspaceController.saveCollection();
       expect($location.path).not.toHaveBeenCalled();


### PR DESCRIPTION
Implements #62. Adds an editable field for the description. 

Note: the collection description should automatically propagate to Mirador (via the IIIF manifest generated by the API) so you can view it in the "info" panel.

---
![screen shot 2016-04-19 at 4 56 42 pm](https://cloud.githubusercontent.com/assets/1165361/14655321/c0b24672-064f-11e6-804b-b746fc78665b.png)

![screen shot 2016-04-19 at 4 56 52 pm](https://cloud.githubusercontent.com/assets/1165361/14655323/c253a41c-064f-11e6-973d-5a1184f4b65c.png)
---

@jazahn @MichaelDHilborn-Harvard Review?
