### PR TITLE
bugfix: collection drag not visible to students

### DIFF
--- a/app/src/templates/collections.html
+++ b/app/src/templates/collections.html
@@ -13,8 +13,8 @@
 
 <ul class="list-group" as-sortable="lc.dragControlListeners" ng-model="lc.collections">
   <li class="list-group-item clearfix" ng-repeat="collection in lc.collections | filter:query" as-sortable-item>
-    <div class="glyphicon glyphicon-menu-hamburger pull-left collection-drag-handle" as-sortable-item-handle aria-hidden="true"></div>
     <div ng-if="lc.canEdit">
+      <div class="glyphicon glyphicon-menu-hamburger pull-left collection-drag-handle" as-sortable-item-handle aria-hidden="true"></div>
       <div class="btn-group dropdown pull-right" uib-dropdown="" is-open="status.isopen" style="">
         <button id="single-button" type="button" class="collection-edit-button btn btn-default btn-sm dropdown-toggle" uib-dropdown-toggle="" ng-disabled="disabled" aria-haspopup="true" aria-expanded="false">
           <span class="glyphicon glyphicon-cog" aria-hidden="true"></span>


### PR DESCRIPTION
This PR fixes #59 

- [x] when viewed as a student, the drag handle is not visible
- [x] when viewed as an admin, the drag handle is visible and usable

@arthurian @MichaelDHilborn-Harvard review please?