### PR TITLE
Refactor image library views as components

### DIFF
--- a/app/src/css/components.css
+++ b/app/src/css/components.css
@@ -143,7 +143,6 @@
   width: 100%;
 }
 .library__table thead {
-  border-bottom: 1px solid #ccc;
 }
 .library__table th, .library__table td {
   padding: 5px;
@@ -206,5 +205,13 @@
 }
 .library__container-web-images input[type="url"]:valid {}
 .library__container-web-images input[type="url"]:not(:placeholder-shown) {}
-
-
+.library__image {
+  cursor: pointer;
+  display: block;
+  margin: auto;
+  max-width: 100%;
+  max-height: 100%;
+}
+.library__thumbimage {
+  width: 125px;
+}

--- a/app/src/js/components/collectionEditLibrary.js
+++ b/app/src/js/components/collectionEditLibrary.js
@@ -9,6 +9,31 @@ angular.module('media_manager')
     var ctrl = this;
     var LOOKUP_SELECTED = {};
 
+    ctrl.filterByTitle = function(query) {
+      if(!query) {
+        return function() { return true; };
+      }
+      query = query.trim().toLowerCase();
+      return function(obj) {
+        var title = obj.title.toLowerCase();
+        return title.indexOf(query) !== -1;
+      };
+    };
+
+    ctrl.filterImages = function(query) {
+      var valid_query = (typeof query === "string" && query.trim().length > 0);
+      if(valid_query) {
+        ctrl.filteredCourseImages = ctrl.courseImages.filter(ctrl.filterByTitle(query));
+      } else {
+        ctrl.filteredCourseImages = ctrl.courseImages.slice(0);
+      }
+    };
+
+    ctrl.resetFilter = function() {
+      ctrl.imagequery = '';
+      ctrl.filterImages(null);
+    };
+
     ctrl.getCourseImages = function() {
       var images =  CourseCache.images || [];
       return images.filter(ctrl.courseImageHasUrl);
@@ -27,6 +52,7 @@ angular.module('media_manager')
 
     ctrl.updateCourseImages = function() {
       ctrl.courseImages = ctrl.getCourseImages(); // break old reference so component detects the change
+      ctrl.filterImages(ctrl.imagequery);
     };
 
     ctrl.updateLayout = function(layout) {
@@ -127,14 +153,15 @@ angular.module('media_manager')
       ctrl.fileStats = {filesToUpload: 0, fileUploadSize: 0};
       ctrl.webimage = {title: "", url:""};
       ctrl.sortChoices = [
+        {'label': 'Default Order', 'name': 'sort_order', 'dir': 'asc'},
         {'label': 'Newest to Oldest', 'name': 'created', 'dir': 'desc'},
         {'label': 'Oldest to Newest', 'name': 'created', 'dir': 'asc'},
         {'label': 'Title', 'name': 'title', 'dir': 'asc'},
-        {'label': 'Default Order', 'name': 'sort_order', 'dir': 'asc'},
       ];
 
       ctrl.courseImages = ctrl.getCourseImages();
-      ctrl.sortLibrary(ctrl.sortChoices[0]);
+      ctrl.filteredCourseImages = ctrl.courseImages;
+      ctrl.sortLibrary(ctrl.sortChoices[1]);
       ctrl.updateLayout(Preferences.get(Preferences.UI_WORKSPACE_LAYOUT));
 
       $log.log("initialized collectionEditLibrary", ctrl);

--- a/app/src/js/components/imageLibraryGallery.js
+++ b/app/src/js/components/imageLibraryGallery.js
@@ -1,0 +1,31 @@
+angular.module('media_manager').component('appImageLibraryGallery', {
+  templateUrl: '/static/app/templates/imageLibraryGallery.html',
+  bindings: {
+    courseImages: "<",
+    onAddToCollection: "&",
+    onInCollection: "&",
+  },
+  controller: ['$log', '$location', function($log, $location) {
+    var ctrl = this;
+
+    ctrl.addToCollection = function(courseImage) {
+      ctrl.onAddToCollection({ "$event": courseImage });
+    };
+
+    ctrl.inCollection = function(courseImage) {
+      return ctrl.onInCollection({ "$event": courseImage });
+    };
+
+    ctrl.goToImageView = function (courseImage) {
+      $location.path('/image/' + courseImage.id);
+    };
+
+    ctrl.$onInit = function() {};
+    ctrl.$onChanges = function(changes) {
+      $log.log("imageLibraryGalleryChanges", changes);
+      if(changes.hasOwnProperty('courseImages') && !changes.courseImages.isFirstChange()) {
+        ctrl.courseImages = changes.courseImages.currentValue;
+      }
+    };
+  }]
+});

--- a/app/src/js/components/imageLibraryList.js
+++ b/app/src/js/components/imageLibraryList.js
@@ -1,0 +1,32 @@
+angular.module('media_manager').component('appImageLibraryList', {
+  templateUrl: '/static/app/templates/imageLibraryList.html',
+  bindings: {
+    courseImages: "<",
+    onAddToCollection: "&",
+    onInCollection: "&",
+  },
+  controller: ['$log', '$location', '$scope', function($log, $location, $scope) {
+    var ctrl = this;
+
+    ctrl.addToCollection = function(courseImage) {
+      ctrl.onAddToCollection({ "$event": courseImage });
+    };
+
+    ctrl.inCollection = function(courseImage) {
+      return ctrl.onInCollection({ "$event": courseImage });
+    };
+
+    ctrl.goToImageView = function (courseImage) {
+      $location.path('/image/' + courseImage.id);
+    };
+
+    ctrl.$onInit = function() {};
+    ctrl.$onChanges = function(changes) {
+      $log.log("imageLibraryListChanges", changes);
+      if(changes.hasOwnProperty('courseImages') && !changes.courseImages.isFirstChange()) {
+        ctrl.courseImages = changes.courseImages.currentValue;
+      }
+    };
+
+  }]
+});

--- a/app/src/js/controllers/ImageController.js
+++ b/app/src/js/controllers/ImageController.js
@@ -53,7 +53,7 @@ angular.module('media_manager')
     ic.current_image          = CourseCache.images[index];
 
     if(ic.current_image.image_width < 400) {
-      ic.current_image_small_url = ic.current_image.iiif_base_url + '/full/full/0/default.jpg';
+      ic.current_image_url = ic.current_image.iiif_base_url + '/full/full/0/default.jpg';
     } else {
       ic.current_image_url = ic.current_image.iiif_base_url + '/full/400,/0/default.jpg';
     }

--- a/app/src/templates/collectionEditLibrary.html
+++ b/app/src/templates/collectionEditLibrary.html
@@ -74,8 +74,17 @@
     </h4>
 
     <div ng-if="$ctrl.courseImages.length > 0">
-      <div style="margin-top: 20px">
-          <div class="btn-group pull-left" uib-dropdown>
+      <div style="margin-top: 10px;">
+        <div class="input-group">
+          <input type="text" name="imagequery" class="form-control" placeholder="Filter images by title" aria-label="Filter images by title" ng-model="$ctrl.imagequery" ng-keydown="$event.keyCode === 13 && $ctrl.filterImages($ctrl.imagequery)"  />
+          <div class="input-group-btn">
+            <button ng-click="$ctrl.resetFilter()" ng-show="$ctrl.imagequery" class="btn btn-default" aria-label="Clear Filter">&times;</button>
+            <button ng-click="$ctrl.filterImages($ctrl.imagequery)" class="btn btn-default">Filter</button>
+          </div>
+        </div>
+      </div>
+      <div style="margin-top: 20px;">
+          <div class="btn-group pull-left" style="margin-right: 20px;" uib-dropdown>
               <button id="sort_images_button" type="button" class="btn btn-default" uib-dropdown-toggle ng-disabled="disabled">
                 Sort Images <span class="caret"></span>
               </button>
@@ -85,52 +94,19 @@
                   </li>
               </ul>
           </div>
-          <div class="pull-left" style="margin-left: 20px;">
+          <div class="pull-left" style="margin-right: 20px;">
               Layout:
               <div class="btn-group" role="group" aria-label="layout">
                 <button class="btn btn-default" ng-click="$ctrl.setLayoutGallery()" ng-class="{'active':$ctrl.isLayoutGallery}">Gallery</button>
                 <button class="btn btn-default" ng-click="$ctrl.setLayoutList()" ng-class="{'active':$ctrl.isLayoutList}">List</button>
               </div>
           </div>
+          <br style="clear:both;">
       </div>
 
-      <div style="clear:both; padding: 10px;">
-          <ul class="files list-inline" ng-class="{'hidden':!$ctrl.isLayoutGallery}">
-            <li class="droplet-thumb" ng-repeat="courseImage in $ctrl.courseImages track by $index">
-              <droplet-thumb ng-model="courseImage"></droplet-thumb>
-              <div ng-show="!$ctrl.inCollection(courseImage)" class="overlay" ng-click="$ctrl.addToCollection(courseImage)">+</div>
-              <div ng-show="$ctrl.inCollection(courseImage)" class="overlay overlay-stay">
-                <span class="glyphicon glyphicon-ok" aria-hidden="true"></span>
-              </div>
-              <div class="resize-overlay" ng-click="$ctrl.goToImageView(courseImage)">
-                <span class="glyphicon glyphicon-info-sign" aria-hidden="true"></span>
-              </div>
-            </li>
-          </ul>
-          <table class="library__table" ng-class="{'hidden':!$ctrl.isLayoutList}" aria-hidden="true">
-              <thead>
-                  <tr>
-                      <th>Image</th>
-                      <th>Title</th>
-                      <th style="width:90px">Actions</th>
-                  </tr>
-              </thead>
-              <tbody>
-                  <tr ng-repeat="courseImage in $ctrl.courseImages track by $index">
-                      <td style="width:125px;"><droplet-thumb ng-model="courseImage" uib-tooltip="{{courseImage.title}}"></droplet-thumb></td>
-                      <td class="break-word"><span uib-tooltip='Uploaded: {{courseImage.created | asDate | date:"MM/dd/yy @ h:mma"}}'>{{courseImage.title}}</span></td>
-                      <td style="white-space:nowrap;">
-                        <button class="btn btn-default" ng-click="$ctrl.goToImageView(courseImage)" uib-tooltip="Edit Image">
-                          <span class="glyphicon glyphicon-pencil" aria-hidden="true"></span>
-                        </button>
-                        <button ng-disabled="$ctrl.inCollection(courseImage)" class="btn btn-primary" ng-click="$ctrl.addToCollection(courseImage)" uib-tooltip="Add to Collection">
-                          <span ng-show="!$ctrl.inCollection(courseImage)" class="glyphicon glyphicon-plus-sign" aria-hidden="true"></span>
-                          <span ng-show="$ctrl.inCollection(courseImage)" class="glyphicon glyphicon-ok" aria-hidden="true" uib-tooltip="Already in Collection"></span>
-                        </button>
-                      </td>
-                  </tr>
-              </tbody>
-          </table>
+      <div style="margin-top: 20px; padding: 0 10px; ">
+        <app-image-library-gallery ng-class="{'hidden':!$ctrl.isLayoutGallery}" course-images="$ctrl.filteredCourseImages" on-add-to-collection="$ctrl.addToCollection($event)" on-in-collection="$ctrl.inCollection($event)"></app-image-library-gallery>
+        <app-image-library-list ng-class="{'hidden':!$ctrl.isLayoutList}" course-images="$ctrl.filteredCourseImages" on-add-to-collection="$ctrl.addToCollection($event)" on-in-collection="$ctrl.inCollection($event)"></app-image-library-list>
       </div>
     </div>
 </div>

--- a/app/src/templates/image.html
+++ b/app/src/templates/image.html
@@ -28,7 +28,7 @@
         <h4>{{ ic.CourseCache.current_image.title || "Untitled" }}</h4>
       </div>
       <div class="col-md-12 text-center" style="height: 400px;">
-        <img style="cursor: pointer; display: block;margin: auto; max-width: 100%; max-height: 100%;" ng-src="{{ ic.current_image_url }}" ng-click="ic.openFullImage(ic.current_image)" />
+        <img class="library__image" ng-src="{{ ic.current_image_url }}" ng-click="ic.openFullImage(ic.current_image)" />
       </div>
       <div class="col-md-12 text-center">
         <p>{{ic.CourseCache.current_image.description||'No Description'}}</p>

--- a/app/src/templates/imageLibraryGallery.html
+++ b/app/src/templates/imageLibraryGallery.html
@@ -1,0 +1,12 @@
+<ul class="files list-inline">
+    <li class="droplet-thumb" ng-repeat="courseImage in $ctrl.courseImages">
+      <droplet-thumb ng-model="courseImage"></droplet-thumb>
+      <div ng-show="!$ctrl.inCollection(courseImage)" class="overlay" ng-click="$ctrl.addToCollection(courseImage)">+</div>
+      <div ng-show="$ctrl.inCollection(courseImage)" class="overlay overlay-stay">
+        <span class="glyphicon glyphicon-ok" aria-hidden="true"></span>
+      </div>
+      <div class="resize-overlay" ng-click="$ctrl.goToImageView(courseImage)">
+        <span class="glyphicon glyphicon-info-sign" aria-hidden="true"></span>
+      </div>
+    </li>
+</ul>

--- a/app/src/templates/imageLibraryList.html
+++ b/app/src/templates/imageLibraryList.html
@@ -1,0 +1,30 @@
+<table class="library__table" aria-hidden="true">
+  <thead>
+      <tr>
+          <th>Image</th>
+          <th>Title</th>
+          <th style="width:90px">Actions</th>
+      </tr>
+  </thead>
+  <tbody>
+      <tr ng-repeat="courseImage in $ctrl.courseImages">
+          <td class="library__thumbimage">
+            <droplet-thumb ng-model="courseImage"></droplet-thumb>
+            <span style="font-size: 11px; color: #999; font-style: italic;">{{courseImage.created | asDate | date:"MM/dd/yy"}}</span>
+          </td>
+          <td class="break-word" >
+            <div uib-tooltip="{{courseImage.description}}">{{courseImage.title}}</div>
+          </td>
+          <td style="white-space:nowrap;">
+            <button class="btn btn-default" ng-click="$ctrl.goToImageView(courseImage)" uib-tooltip="Edit Image">
+              <span class="glyphicon glyphicon-pencil" aria-hidden="true"></span>
+            </button>
+            <button ng-disabled="$ctrl.inCollection(courseImage)" class="btn btn-primary" ng-click="$ctrl.addToCollection(courseImage)" uib-tooltip="Add to Collection">
+              <span ng-show="!$ctrl.inCollection(courseImage)" class="glyphicon glyphicon-plus-sign" aria-hidden="true"></span>
+              <span ng-show="$ctrl.inCollection(courseImage)" class="glyphicon glyphicon-ok" aria-hidden="true" uib-tooltip="Already in Collection"></span>
+            </button>
+          </td>
+      </tr>
+  </tbody>
+</table>
+


### PR DESCRIPTION
This PR refactors image library layouts as components (e.g. they each have their own template and controller now), fixes a small bug in the image controller, restores the _Default Order_ for sorting, and adds the ability to filter the library of images by title. 

Note that the _Default Order_ is intended to be used to create a custom ordering of the library. There is currently no UI mechanism that exposes this custom ordering, but the intention is to provide this functionality later.