### PR TITLE
Python 2 to 3 and Django 1.11 LTS to 2.2 LTS upgrade

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,17 @@
+[run]
+source = .
+omit =
+    */node_modules/*
+    manage.py
+    media_management_lti/*
+    media_manager/migrations/*
+    media_manager/templatetags/*
+    media_manager/mixins.py
+    media_manager/services.py
+    media_manager/lti.py
+    media_manager/decorators.py
+branch = True
+
+[report]
+show_missing = True
+skip_covered = True

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,16 @@ app/.*.json
 
 # Mirador
 #/app/src/vendor/mirador
+
+# Auto-generated backup files
+*.bak
+
+# Any SSL keys/certs
+*.pem
+
+# Files that `coverage` generates
+htmlcov/
+.coverage
+.coverage.*
+coverage.xml
+*.cover

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 language: python
 python:
-- '2.7'
+- '3.6'
 env:
 - DJANGO_SETTINGS_MODULE="media_management_lti.settings.local"
 install:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM python:2.7
+FROM python:3.6
 ENV PYTHONUNBUFFERED 1
 RUN mkdir /code
 WORKDIR /code
 ADD . /code/
-RUN pip install -r media_management_lti/requirements/base.txt
+RUN pip install -r media_management_lti/requirements/local.txt

--- a/README.md
+++ b/README.md
@@ -30,6 +30,11 @@ $ cp media_management_lti/settings/secure.py.example media_management_lti/settin
 - Generate API credentials on the [media_management_api](https://github.com/Harvard-ATG/media_management_api)  admin interface
 - Update `media_management_lti/settings/secure.py` with the client_id and client_secret that were generated. These API credentials are used to obtain API tokens for end-users.
 
+**Install TLS certificates to [support HTTPS on localhost](https://blog.filippo.io/mkcert-valid-https-certificates-for-localhost/)**
+- Install the [mkcert tool](https://github.com/FiloSottile/mkcert). E.g, `$ brew install mkcert` on MacOS.
+- Run `$ mkcert -install` and `$ mkcert localhost 127.0.0.1`. A TLS certificate and key pair will be generated. See output for the location of the pair on your filesystem.
+- Update the `runsslserver` command in ./docker-compose.yml with the paths to the TLS certificate and key. Alternatively, as expected by ./docker-compose.yml, rename the certificate to `cert.pem` and the key to `key.pem`, and ensure they are in project root, i.e. ./cert.pem and ./key.pem.
+
 **Start docker services:**
 
 ```
@@ -67,5 +72,5 @@ to the volume that was mounted (e.g. current directory).
 **Other tasks:**
 
 - Access the database: `docker-compose exec db psql -U media_management_lti`
-- Run unit tests: `docker-compose exec web python manage.py test`
+- Run unit tests: `bash run-tests.sh`
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
   web:
     build: .
     image: harvard-atg/media_management_lti:dev
-    command: ["./wait-for-it.sh", "db:5432", "--", "python", "manage.py", "runserver", "0.0.0.0:8080"]
+    command: ["./wait-for-it.sh", "db:5432", "--", "python", "manage.py", "runsslserver", "--certificate", "cert.pem", "--key", "key.pem", "0.0.0.0:8080"]
     volumes:
       - .:/code
     ports:
@@ -22,7 +22,7 @@ services:
       - db
       - redis
     environment:
-      DJANGO_SETTINGS_MODULE: media_management_lti.settings.local
+      DJANGO_SETTINGS_MODULE: media_management_lti.settings.test
     networks:
       default:
       public:

--- a/media_management_lti/middleware.py
+++ b/media_management_lti/middleware.py
@@ -1,11 +1,12 @@
+from builtins import object
 from media_manager.lti import LTILaunchError
-#from django.utils.deprecation import MiddlewareMixin
+from django.utils.deprecation import MiddlewareMixin
 from django.http import HttpResponse
 import logging
 
 logger = logging.getLogger(__name__)
 
-class LtiExceptionMiddleware(object):
+class LtiExceptionMiddleware(MiddlewareMixin):
     def process_exception(self, request, exception):
         if isinstance(exception, LTILaunchError):
             logger.error(exception.message)

--- a/media_management_lti/requirements/base.txt
+++ b/media_management_lti/requirements/base.txt
@@ -1,11 +1,11 @@
-Django==1.11.29
+Django~=2.2.0
 # Postgres
-psycopg2==2.7.7
+psycopg2==2.8.5
 # Redis Cache
-redis==2.10.6
-django-redis-cache==1.7.1
-hiredis==0.2.0
-requests==2.22.0
+redis==3.5.3
+django-redis-cache==2.1.1
+hiredis==1.1.0
 
-#git+https://github.com/Harvard-University-iCommons/django-auth-lti.git@v1.2.9#egg=django-auth-lti==1.2.9
-git+https://github.com/Harvard-ATG/django_auth_lti.git@multi-launch-remove-ordered-dict#egg=django-auth-lti==1.3.1
+requests==2.24.0
+
+git+https://github.com/Harvard-University-iCommons/django-auth-lti.git@v2.0.1#egg=django-auth-lti==2.0.1

--- a/media_management_lti/requirements/local.txt
+++ b/media_management_lti/requirements/local.txt
@@ -5,6 +5,8 @@
  
 # below are requirements specific to the local environment
 django-debug-toolbar==1.3.2
-mock==1.3.0
-pep8==1.6.2
-flake8==2.4.1
+mock==4.0.2
+pep8==1.7.1
+flake8==3.8.3
+django-sslserver==0.22
+coverage==5.3

--- a/media_management_lti/settings/base.py
+++ b/media_management_lti/settings/base.py
@@ -40,13 +40,12 @@ INSTALLED_APPS = [
     'media_manager',
 ]
 
-MIDDLEWARE_CLASSES = [
+MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
-    'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
     'django_auth_lti.middleware_patched.MultiLTILaunchAuthMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'media_management_lti.middleware.LtiExceptionMiddleware',
@@ -94,7 +93,7 @@ WSGI_APPLICATION = 'media_management_lti.wsgi.application'
 
 DATABASES = {
     'default': {
-        'ENGINE': 'django.db.backends.postgresql_psycopg2',
+        'ENGINE': 'django.db.backends.postgresql',
         'NAME': SECURE_SETTINGS.get('db_default_name', 'media_management_lti'),
         'USER': SECURE_SETTINGS.get('db_default_user', 'postgres'),
         'PASSWORD': SECURE_SETTINGS.get('db_default_password'),
@@ -243,6 +242,7 @@ LTI_SETUP = {
         }
     }
 }
+
 
 # Loads the application build JSON file.
 # This file maps JS/CSS build file names to their hashed version. For example:

--- a/media_management_lti/settings/local.py
+++ b/media_management_lti/settings/local.py
@@ -8,13 +8,16 @@ EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
 SESSION_ENGINE = 'django.contrib.sessions.backends.file'
 
 #INSTALLED_APPS += ('debug_toolbar',)
-#MIDDLEWARE_CLASSES += ('debug_toolbar.middleware.DebugToolbarMiddleware',)
+#MIDDLEWARE += ('debug_toolbar.middleware.DebugToolbarMiddleware',)
 
 # For Django Debug Toolbar:
 INTERNAL_IPS = ('127.0.0.1', '10.0.2.2',)
 DEBUG_TOOLBAR_CONFIG = {
     'INTERCEPT_REDIRECTS': False,
 }
+
+# For enabling HTTPS in local development. See https://github.com/teddziuba/django-sslserver
+INSTALLED_APPS += ('sslserver',)
 
 # Logging
 

--- a/media_management_lti/staticfiles.py
+++ b/media_management_lti/staticfiles.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 from django.contrib.staticfiles import storage
 from django.core.files.base import File
 from django.conf import settings
@@ -78,18 +79,18 @@ class StaticFilesStorage(storage.StaticFilesStorage):
 
         # Run the commands.
         for cmd in (NPM_INSTALL, BOWER_INSTALL, GULP_BUILD):
-            print "\n%s%s%s\n" % ("*" * 25, cmd, "*" * 25)
+            print("\n%s%s%s\n" % ("*" * 25, cmd, "*" * 25))
             which_cmd = cmd[0]
-            print "Which [%s]?" % which_cmd
+            print("Which [%s]?" % which_cmd)
             found_cmd = subprocess.check_output(['/usr/bin/which', which_cmd], **subprocess_args).strip()
-            print "Found [%s] at [%s]" % (which_cmd, found_cmd)
+            print("Found [%s] at [%s]" % (which_cmd, found_cmd))
             cmd[0] = found_cmd
-            print "Running cmd [%s] with args [%s]\n" % (' '.join(cmd), subprocess_args)
+            print("Running cmd [%s] with args [%s]\n" % (' '.join(cmd), subprocess_args))
             child = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, **subprocess_args)
             (stdoutdata, stderrdata) = child.communicate()
             while child.returncode is None:
                 continue
-            print "%s\n%s\n" % (stdoutdata, stderrdata)
+            print("%s\n%s\n" % (stdoutdata, stderrdata))
 
     def hash_build_files(self):
         """
@@ -106,13 +107,13 @@ class StaticFilesStorage(storage.StaticFilesStorage):
                 can_hash_file = (name.endswith('.js') or name.endswith('.css')) and re.match(file_pattern, name) is None
                 if can_hash_file:
                     orig_file_path = os.path.join(root, name)
-                    print "Hashing file: %s" % orig_file_path
+                    print("Hashing file: %s" % orig_file_path)
                     with open(orig_file_path, 'rb') as f:
                         hash_result = self.file_hash(File(f))
                         (file_name, file_extension) = os.path.splitext(name)
                         new_file_path = os.path.join(root, "%s-%s%s" % (file_name, hash_result, file_extension))
                         hashed_files[orig_file_path] = new_file_path
-                        print "Copying file %s to %s" % (orig_file_path, new_file_path)
+                        print("Copying file %s to %s" % (orig_file_path, new_file_path))
                         shutil.copyfile(orig_file_path, new_file_path)
 
         return hashed_files
@@ -128,7 +129,7 @@ class StaticFilesStorage(storage.StaticFilesStorage):
         build_manifest = {}
         strip_src_path = BUILD_SRC + "/"
         strip_dst_path = settings.BASE_DIR + "/"
-        for original_path, hashed_path in hashed_files.iteritems():
+        for original_path, hashed_path in hashed_files.items():
             src = original_path.replace(strip_src_path, '')
             dst = hashed_path.replace(strip_dst_path, '')
             build_manifest[src] = dst
@@ -136,8 +137,8 @@ class StaticFilesStorage(storage.StaticFilesStorage):
         # Write the JSON file with the mappings
         manifest_file = MANIFEST_FILE
         manifest_json = json.dumps(build_manifest)
-        print "Build manifest: %s" % manifest_json
-        print "Writing build manifest: %s" % manifest_file
+        print("Build manifest: %s" % manifest_json)
+        print("Writing build manifest: %s" % manifest_file)
         with open(manifest_file, 'w') as f:
             f.write(manifest_json)
 
@@ -149,9 +150,9 @@ class StaticFilesStorage(storage.StaticFilesStorage):
             (BUILD_SRC, BUILD_DST),
         ]
         for (src, dst) in copies:
-            print "Copying tree %s to %s" % (src, dst)
+            print("Copying tree %s to %s" % (src, dst))
             if os.path.exists(dst):
-                print "Deleting tree %s" % dst
+                print("Deleting tree %s" % dst)
                 shutil.rmtree(dst)
             shutil.copytree(src, dst)
 
@@ -161,10 +162,10 @@ class StaticFilesStorage(storage.StaticFilesStorage):
         """
         build_tree = os.path.join(BUILD_SRC, 'app')
         if os.path.exists(build_tree):
-            print "Deleting build source tree %s" % build_tree
+            print("Deleting build source tree %s" % build_tree)
             shutil.rmtree(build_tree)
         if os.path.exists(MANIFEST_FILE):
-            print "Deleting build manifest %s" % MANIFEST_FILE
+            print("Deleting build manifest %s" % MANIFEST_FILE)
             os.remove(MANIFEST_FILE)
 
     def file_hash(self, content=None):

--- a/media_management_lti/urls.py
+++ b/media_management_lti/urls.py
@@ -12,12 +12,12 @@ Including another URLconf
     1. Add an import:  from blog import urls as blog_urls
     2. Add a URL to urlpatterns:  url(r'^blog/', include(blog_urls))
 """
-from django.conf.urls import include, url
+from django.urls import include, path
 from django.contrib import admin
 from media_manager import views
 
 urlpatterns = [
-     url(r'^admin/', admin.site.urls),
-    #url(r'^lti/', include('django_app_lti.urls', namespace="lti")),
-    url(r'^', include('media_manager.urls', namespace="media_manager")),
+    path('admin/', admin.site.urls),
+    #path('lti/', include('django_app_lti.urls', namespace="lti")),
+    path('', include('media_manager.urls', namespace="media_manager")),
 ]

--- a/media_manager/lti.py
+++ b/media_manager/lti.py
@@ -1,3 +1,4 @@
+from builtins import object
 from django.core.exceptions import PermissionDenied
 import re
 import logging
@@ -19,7 +20,7 @@ class LTILaunch(object):
         elif 'LTI_LAUNCH' not in self.request.session:
             raise LTILaunchError("Session is missing LTI_LAUNCH dict.")
         else:
-            session_keys = self.request.session['LTI_LAUNCH'].keys()
+            session_keys = list(self.request.session['LTI_LAUNCH'].keys())
             if len(session_keys) == 0:
                 raise LTILaunchError("Session LTI_LAUNCH dict is empty")
 

--- a/media_manager/migrations/0002_coursemodule.py
+++ b/media_manager/migrations/0002_coursemodule.py
@@ -20,7 +20,7 @@ class Migration(migrations.Migration):
                 ('api_collection_id', models.IntegerField(null=True)),
                 ('created', models.DateTimeField(auto_now_add=True)),
                 ('updated', models.DateTimeField(auto_now=True)),
-                ('course', models.ForeignKey(to='media_manager.Course')),
+                ('course', models.ForeignKey(on_delete=models.CASCADE, to='media_manager.Course')),
             ],
             options={
                 'verbose_name': 'module',

--- a/media_manager/mixins.py
+++ b/media_manager/mixins.py
@@ -1,3 +1,4 @@
+from builtins import object
 import json
 
 class JsonMixin(object):

--- a/media_manager/models.py
+++ b/media_manager/models.py
@@ -1,3 +1,4 @@
+from builtins import object
 from django.db import models
 
 class Course(models.Model):
@@ -7,7 +8,7 @@ class Course(models.Model):
     created = models.DateTimeField(auto_now_add=True)
     updated = models.DateTimeField(auto_now=True)
 
-    class Meta:
+    class Meta(object):
         verbose_name = 'course'
         verbose_name_plural = 'courses'
         unique_together = ("lti_context_id", "lti_tool_consumer_instance_guid")
@@ -23,7 +24,7 @@ class CourseModule(models.Model):
     created = models.DateTimeField(auto_now_add=True)
     updated = models.DateTimeField(auto_now=True)
 
-    class Meta:
+    class Meta(object):
         verbose_name = 'module'
         verbose_name_plural = 'module'
 

--- a/media_manager/services.py
+++ b/media_manager/services.py
@@ -1,3 +1,4 @@
+from builtins import object
 from django.conf import settings
 from django.core.exceptions import PermissionDenied
 from media_manager.models import Course

--- a/media_manager/tests.py
+++ b/media_manager/tests.py
@@ -1,0 +1,68 @@
+from django.test import TestCase
+from .models import Course, CourseModule
+
+
+# Variables for use in unit tests
+LTI_CONTEXT_ID = 'some_context_id'
+LTI_TOOL_CONSUMER_INSTANCE_GUID = 'some_guid'
+API_COURSE_ID = 1
+LTI_RESOURCE_LINK_ID = 'some_resource_link_id'
+LTI_RESOURCE_LINK_TITLE = 'some_resource_link_title'
+API_COLLECTION_ID = 1
+
+# Test class for the "Course" model
+class CourseModelTest(TestCase):
+    
+    def setUp(self):
+        """
+        Create a Course object.
+        """
+        Course.objects.create(
+            lti_context_id = LTI_CONTEXT_ID,
+            lti_tool_consumer_instance_guid = LTI_TOOL_CONSUMER_INSTANCE_GUID,
+            api_course_id = API_COURSE_ID
+        )
+    
+    def test_creation_of_a_course(self):
+        """
+        Test the successful creation of a Course object..
+        """
+        course = Course.objects.get(id=1)
+        self.assertEqual(course.lti_context_id, LTI_CONTEXT_ID)
+        self.assertEqual(course.lti_tool_consumer_instance_guid, LTI_TOOL_CONSUMER_INSTANCE_GUID)
+        self.assertEqual(course.api_course_id, API_COURSE_ID)
+
+# Test class for the "CourseModule" model
+class CourseModuleModelTest(TestCase):
+
+    def setUp(self):
+        """
+        Create a CourseModule object.
+        """
+        sample_course_obj = Course.objects.create(
+            lti_context_id = LTI_CONTEXT_ID,
+            lti_tool_consumer_instance_guid = LTI_TOOL_CONSUMER_INSTANCE_GUID,
+            api_course_id = API_COURSE_ID
+        )
+
+        CourseModule.objects.create(
+            course = sample_course_obj,
+            lti_resource_link_id = LTI_RESOURCE_LINK_ID,
+            lti_resource_link_title = LTI_RESOURCE_LINK_TITLE,
+            api_collection_id = API_COURSE_ID
+        )
+
+    def test_creation_of_a_course_module(self):
+        """
+        Test the successful creation of a CourseModule object.
+        """
+        course_module = CourseModule.objects.get(id=1)
+        self.assertEqual(course_module.lti_resource_link_id, LTI_RESOURCE_LINK_ID)
+        self.assertEqual(course_module.lti_resource_link_title, LTI_RESOURCE_LINK_TITLE)
+        self.assertEqual(course_module.api_collection_id, API_COLLECTION_ID)
+
+# TODO: Add more unit tests
+
+
+
+

--- a/media_manager/urls.py
+++ b/media_manager/urls.py
@@ -12,15 +12,18 @@ Including another URLconf
     1. Add an import:  from blog import urls as blog_urls
     2. Add a URL to urlpatterns:  url(r'^blog/', include(blog_urls))
 """
-from django.conf.urls import include, url
+from __future__ import absolute_import
+from django.urls import include, path
 from django.contrib import admin
-import views
+from . import views
+
+app_name = "media_manager"
 
 urlpatterns = [
-    url(r'^$', views.app, name='index'),
-    url(r'^app$', views.app, name='app'),
-    url(r'^mirador/(?P<collection_id>[0-9]+)$', views.mirador, name="mirador"),
-    url(r'^endpoints/module$', views.module_endpoint, name="module_endpoint"),
-    url(r'^lti/launch$', views.LTILaunchView.as_view(), name="lti_launch"),
-    url(r'^lti/config$', views.LTIToolConfigView.as_view(), name="lti_config"),
+    path('', views.app, name='index'),
+    path('app', views.app, name='app'),
+    path('mirador/<int:collection_id>', views.mirador, name="mirador"),
+    path('endpoints/module', views.module_endpoint, name="module_endpoint"),
+    path('lti/launch', views.LTILaunchView.as_view(), name="lti_launch"),
+    path('lti/config', views.LTIToolConfigView.as_view(), name="lti_config"),
 ]

--- a/media_manager/views.py
+++ b/media_manager/views.py
@@ -1,3 +1,4 @@
+from builtins import object
 from django.conf import settings
 from django.shortcuts import render
 from django.http import HttpResponse, Http404, HttpResponseRedirect
@@ -7,7 +8,7 @@ from django.contrib.auth.decorators import login_required
 from django.views.decorators.http import require_http_methods
 from django.views.decorators.csrf import csrf_exempt
 from django.urls import reverse
-from ims_lti_py.tool_config import ToolConfig
+from lti import ToolConfig
 from media_manager.models import CourseModule
 from media_manager.services import CourseService
 from media_manager.lti import LTILaunch
@@ -207,9 +208,6 @@ class MiradorView(PageView):
         }
         return render(self.request, 'mirador.html', context=context)
 
-import django_auth_lti.patch_reverse
-
-
 class LTILaunchView(View):
     @method_decorator(csrf_exempt)
     def dispatch(self, *args, **kwargs):
@@ -246,7 +244,6 @@ class LTIToolConfigView(View):
         '''
         Gets extension parameters on the ToolConfig() instance.
         This includes canvas-specific things like the course_navigation and privacy level:
-
         {
             "canvas.instructure.com": {
                 "privacy_level": "public",

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+set -e  # Configure shell so that if one command fails, it exits
+docker-compose exec web coverage erase
+docker-compose exec web coverage run manage.py test
+docker-compose exec web coverage report
+docker-compose exec web coverage html


### PR DESCRIPTION
This PR introduces the following changes:

- Upgrade of the codebase from python 2.7 to python 2/3. The code is now compatible with both python 2 and python 3.
- Upgrade of the codebase from Django 1.11 LTS to Django 2.2 LTS.
- Switching the local development server from HTTP to HTTPS as [enforced](https://github.com/Harvard-University-iCommons/django-auth-lti/blob/0580633bcb0342af3a34062a510fc2b8572dd395/django_auth_lti/request_validator.py#L16) by [a recent change](https://github.com/Harvard-University-iCommons/django-auth-lti/commit/bcff70c6b9ef4350d926337999f400000c59f2e7#diff-46dbcab89f5912872826d25c0369083b) in the django-auth-lti package.
- Setting up of [coverage](https://coverage.readthedocs.io/en/coverage-5.3/) for measuring code coverage of tests. (I have written a couple of tests and added a `TODO` comment for adding more tests.)

@arthurian, @dodget
